### PR TITLE
scorrodi/concurrent dcs reads

### DIFF
--- a/dtcInterfaceLib/DTC.cpp
+++ b/dtcInterfaceLib/DTC.cpp
@@ -527,9 +527,9 @@ uint16_t DTCLib::DTC::ReadROCRegister(const DTC_Link_ID& link, const uint16_t ad
 	do
 	{
 		dcsDMAInfo_.currentReadPtr = nullptr;
-		ReleaseAllBuffers(DTC_DMA_Engine_DCS);
 
 		device_.begin_dcs_transaction();
+        ReleaseAllBuffers(DTC_DMA_Engine_DCS, true);
 		SendDCSRequestPacket(link, DTC_DCSOperationType_Read, address,
 							0x0 /*data*/, 0x0 /*address2*/, 0x0 /*data2*/,
 							false /*quiet*/);
@@ -1712,7 +1712,7 @@ void DTCLib::DTC::WriteDataPacket(const DTC_DataPacket& packet, bool alreadyHave
 
 	if (errorCode != 0)
 	{
-		DTC_TLOG(TLVL_ERROR) << "WriteDataPacket: write_data returned " << errorCode << ", throwing DTC_IOErrorException!";
+		DTC_TLOG(TLVL_ERROR) << "WriteDataPacket: write_data returned " << errorCode << ", throwing DTC_IOErrorException! alreadyHaveDCSTransactionLock=" << alreadyHaveDCSTransactionLock;
 		throw DTC_IOErrorException(errorCode);
 	}
 }

--- a/dtcInterfaceLib/DTC.h
+++ b/dtcInterfaceLib/DTC.h
@@ -287,7 +287,7 @@ public:
 	/// Release all buffers to the hardware on the given channel
 	/// </summary>
 	/// <param name="channel">Channel to release</param>
-	void ReleaseAllBuffers(const DTC_DMA_Engine& channel)
+	void ReleaseAllBuffers(const DTC_DMA_Engine& channel, bool alreadyHaveDCSTransactionLock = false)
 	{
 		if (channel == DTC_DMA_Engine_DAQ)
 		{
@@ -297,8 +297,10 @@ public:
 		else if (channel == DTC_DMA_Engine_DCS)
 		{
 			dcsDMAInfo_.buffer.clear();
+		if(!alreadyHaveDCSTransactionLock)
 			device_.begin_dcs_transaction();
 			device_.release_all(channel);
+		if(!alreadyHaveDCSTransactionLock)
 			device_.end_dcs_transaction();
 		}		
 	}

--- a/dtcInterfaceLib/DTC.h
+++ b/dtcInterfaceLib/DTC.h
@@ -297,11 +297,9 @@ public:
 		else if (channel == DTC_DMA_Engine_DCS)
 		{
 			dcsDMAInfo_.buffer.clear();
-		if(!alreadyHaveDCSTransactionLock)
-			device_.begin_dcs_transaction();
+		if(!alreadyHaveDCSTransactionLock) device_.begin_dcs_transaction();
 			device_.release_all(channel);
-		if(!alreadyHaveDCSTransactionLock)
-			device_.end_dcs_transaction();
+		if(!alreadyHaveDCSTransactionLock) device_.end_dcs_transaction();
 		}		
 	}
 

--- a/dtcInterfaceLib/mu2edev.cpp
+++ b/dtcInterfaceLib/mu2edev.cpp
@@ -594,15 +594,15 @@ void mu2edev::begin_dcs_transaction()
 	while (retsts == -1 && (tmo_ms <= 0 || std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count() < tmo_ms))
 	{
 		retsts = ioctl(devfd_, M_IOC_DCS_LOCK);
-		if (retsts == -EAGAIN)
+		if ((retsts == -EAGAIN) || ((retsts == -1) && (errno == EAGAIN)))
 		{
-			TRACE(TLVL_DEBUG + 23, UID_ + " begin_dcs_transaction: ioctl returned %d, waiting and retrying", retsts);
+			TRACE(TLVL_DEBUG + 23, UID_ + " begin_dcs_transaction: ioctl returned %d (errno %d), waiting and retrying", retsts, errno);
 			perror("M_IOC_DCS_LOCK");
 			std::this_thread::sleep_for(std::chrono::microseconds(100));
 		}
 		else if (retsts != 0)
 		{
-			TRACE(TLVL_DEBUG + 13, UID_ + " begin_dcs_transaction: Method not supported by driver, taking library lock and returning");
+			TRACE(TLVL_DEBUG + 13, UID_ + " begin_dcs_transaction: Method not supported by driver, taking library lock and returning. ioctl returned %d, errno %d", retsts, errno);
 			dcs_lock_held_ = std::this_thread::get_id();
 			return;
 		}


### PR DESCRIPTION
- change in mu2edev to properly handle the case in which the driver is busy and we want to wait (EAGAIN) before giving the lock to this instance
- changes in DTC to keep the lock for buffer releases and read/writes  