### PR TITLE
release_buffers_held_fix

### DIFF
--- a/dtcInterfaceLib/DTC.cpp
+++ b/dtcInterfaceLib/DTC.cpp
@@ -1594,6 +1594,25 @@ int DTCLib::DTC::ReadBuffer(const DTC_DMA_Engine& channel, int retries /* = 10 *
 	return errorCode;
 } // ReadBuffer
 
+
+void DTCLib::DTC::ReleaseAllBuffers(const DTC_DMA_Engine& channel)
+{
+	TLOG_ENTEX(1) << "ReleaseAllBuffers - channel="<<channel;
+                if (channel == DTC_DMA_Engine_DAQ)
+                {
+                        daqDMAInfo_.buffer.clear();
+                        device_.release_all(channel);
+                }
+                else if (channel == DTC_DMA_Engine_DCS)
+                {
+                        dcsDMAInfo_.buffer.clear();
+                        device_.begin_dcs_transaction();
+                        device_.release_all(channel);
+                        device_.end_dcs_transaction();
+                }
+}
+
+
 // ReleaseBuffers releases the buffers that are held by ReadBuffer,
 // to release all DMA buffers and force hw and sw to align (for DCS) use ReleaseAllBuffers
 void DTCLib::DTC::ReleaseBuffers(const DTC_DMA_Engine& channel)//, int count)//count==0 means all

--- a/dtcInterfaceLib/DTC.h
+++ b/dtcInterfaceLib/DTC.h
@@ -287,21 +287,7 @@ public:
 	/// Release all buffers to the hardware on the given channel
 	/// </summary>
 	/// <param name="channel">Channel to release</param>
-	void ReleaseAllBuffers(const DTC_DMA_Engine& channel)
-	{
-		if (channel == DTC_DMA_Engine_DAQ)
-		{
-			daqDMAInfo_.buffer.clear();
-			device_.release_all(channel);
-		}
-		else if (channel == DTC_DMA_Engine_DCS)
-		{
-			dcsDMAInfo_.buffer.clear();
-			device_.begin_dcs_transaction();
-			device_.release_all(channel);
-			device_.end_dcs_transaction();
-		}		
-	}
+	void ReleaseAllBuffers(const DTC_DMA_Engine& channel);
 
 private:
 	std::unique_ptr<DTC_DataPacket> ReadNextPacket(const DTC_DMA_Engine& channel, int tmo_ms);


### PR DESCRIPTION
the read_buffer routine would always increment "buffers_held_" so that when a DCS read was followed by a DAQ read with multiple buffers available, the system would skip a buffer. I qualified the incrementing of "buffers_held_"