### PR TITLE
Update CFO_Compiler.cpp

### DIFF
--- a/cfoInterfaceLib/CFO_Compiler.cpp
+++ b/cfoInterfaceLib/CFO_Compiler.cpp
@@ -80,7 +80,7 @@ try
 		for(size_t i=0;i<opArguments_.size();++i)
 			if(opArguments_[i].length() == 0) 
 				opArguments_.erase(opArguments_.begin() + i--); //erase and rewind
-			else if(opArguments_[i].length() > 2  && 
+			else if(opArguments_[i].length() >= 2  && 
 				opArguments_[i][0] == '/' && opArguments_[i][1] == '/') //comment to the end
 			{
 				//erase remainder of arguments because they are commented out


### PR DESCRIPTION
Added an equal sign to logic that checks for inline comments as when they written like "// text here" the space would split the string into ["//","text","here"] and then ignore the 2 character "//" and not recognize the comment and assume the text was an argument and throw a compile error