### PR TITLE
Fixed broken inline comments

### DIFF
--- a/cfoInterfaceLib/CFO_Compiler.cpp
+++ b/cfoInterfaceLib/CFO_Compiler.cpp
@@ -80,7 +80,7 @@ try
 		for(size_t i=0;i<opArguments_.size();++i)
 			if(opArguments_[i].length() == 0) 
 				opArguments_.erase(opArguments_.begin() + i--); //erase and rewind
-			else if(opArguments_[i].length() > 2  && 
+			else if(opArguments_[i].length() >= 2  && 
 				opArguments_[i][0] == '/' && opArguments_[i][1] == '/') //comment to the end
 			{
 				//erase remainder of arguments because they are commented out

--- a/cfoInterfaceLib/Commands.txt
+++ b/cfoInterfaceLib/Commands.txt
@@ -7,7 +7,7 @@ LOOP 100 //32-bits
     HEARTBEAT event_mode= 0x000000020
     MARKER 
     WAIT 10 us 
-    INC_TAG //increment event window tag
+    INC_TAG // event window tag
 DO_LOOP
 
 END
@@ -17,7 +17,7 @@ END
 //    HEARTBEAT event_mode= 0x100000019
 //    MARKER 
 //    WAIT 1.7 us 
-//    INC_TAG //increment event window tag
+//    INC_TAG // increment event window tag
 //DO_LOOP
 //
 //LOOP 10000 //32-bits

--- a/cfoInterfaceLib/Commands.txt
+++ b/cfoInterfaceLib/Commands.txt
@@ -7,7 +7,7 @@ LOOP 100 //32-bits
     HEARTBEAT event_mode= 0x000000020
     MARKER 
     WAIT 10 us 
-    INC_TAG // event window tag
+    INC_TAG // increment event window tag
 DO_LOOP
 
 END


### PR DESCRIPTION
Added an equal sign to logic that checks for inline comments as when they written like "// text here" the space would split the string into ["//","text","here"] and then ignore the 2 character "//" and not recognize the comment and assume the text was an argument and throw a compile error